### PR TITLE
Enable configuring cloud resources using a properties file (#3546)

### DIFF
--- a/docs/pct/cloud-resources/cloud-resources.md
+++ b/docs/pct/cloud-resources/cloud-resources.md
@@ -1,0 +1,65 @@
+# Cloud Resources
+
+Currently, the Snowflake and Databricks PCT tests require connectivity to external cloud resources.
+
+These resources require secrets to be able to establish a connection.
+
+During the GitHub workflows, the jobs get these secrets using AWS Secret Manager.
+
+But how local developers can run these? 
+
+_**The steps below assume developers have personal access to these resources**_
+
+## Create a cloud PCT properties file
+
+The first step is to create a properties file like below, replacing `{}` wit the correct value for your personal access.
+
+```properties
+# Snowflake
+
+snowflake.spec.accountName={}
+snowflake.spec.warehouseName={}
+snowflake.spec.databaseName={}
+snowflake.spec.role={}
+snowflake.spec.region=us-east-1
+snowflake.spec.cloudType=aws
+
+snowflake.auth.publicUserName={}
+# These are secrets, and should be careful on sharing
+snowflake.auth.privateKey={}
+snowflake.auth.passPhrase={}
+
+#Dataricks
+
+databricks.spec.hostname={}
+databricks.spec.port=443
+databricks.spec.protocol=https
+databricks.spec.httpPath={}
+
+# These are secrets, and should be careful on sharing
+databricks.auth.apiToken={}
+```
+
+## Running on PURE IDE Light
+
+When starting the PURE IDE Light process, pass the following system property with the location of the file created above:
+
+`-Dpct.external.resources.properties={location of file}`
+
+After this, execute any PCT test using the cloud resource PCT adapter, and it should connect and work as expected. 
+
+## Running individual JUnit test cases 
+
+When executing a PCT test for one of these cloud resources, pass the following system property with the location of the file created above:
+
+`-Dpct.external.resources.properties={location of file}`
+
+## Running Maven Surefire
+
+When executing the cloud resource maven module, you will need to set the resource file as an environment variable:
+
+`PCT_EXTERNAL_RESOURCES_PROPERTIES={location of file}`
+
+Then, you will need to enable the `pct-test` maven profile.
+
+After this, the cloud resources PCT test cases should execute using Maven Surefire. 

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/pom.xml
@@ -184,19 +184,6 @@
 
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-vault-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-shared-vault-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-runtime-java-extension-compiled-functions-pureExtensions</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-ide/legend-engine-pure-ide-light-http-server/src/main/java/org/finos/legend/engine/ide/PureIDEServer.java
@@ -41,8 +41,6 @@ import org.finos.legend.engine.ide.api.find.FindPureFile;
 import org.finos.legend.engine.ide.api.find.FindTextPreview;
 import org.finos.legend.engine.ide.api.source.UpdateSource;
 import org.finos.legend.engine.ide.session.PureSession;
-import org.finos.legend.engine.shared.core.vault.Vault;
-import org.finos.legend.engine.shared.core.vault.aws.AWSVaultImplementation;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProviderHelper;
 import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositorySet;
@@ -50,7 +48,6 @@ import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.Reposit
 import org.finos.legend.pure.m3.serialization.filesystem.usercodestorage.classpath.ClassLoaderCodeStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.regions.Region;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
@@ -67,18 +64,6 @@ public abstract class PureIDEServer extends Application<ServerConfiguration>
     @Override
     public void initialize(Bootstrap<ServerConfiguration> bootstrap)
     {
-        if (System.getProperty("env.AWS_ACCESS_KEY_ID") != null && System.getProperty("env.AWS_SECRET_ACCESS_KEY") != null)
-        {
-            Vault.INSTANCE.registerImplementation(
-                    new AWSVaultImplementation(
-                            System.getProperty("env.AWS_ACCESS_KEY_ID"),
-                            System.getProperty("env.AWS_SECRET_ACCESS_KEY"),
-                            Region.US_EAST_1,
-                            "snowflake.INTEGRATION_USER1"
-                    )
-            );
-        }
-
         bootstrap.addBundle(new SwaggerBundle<ServerConfiguration>()
         {
             @Override

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-PCT/legend-engine-pure-functions-relationalStore-PCT-pure/src/main/resources/core_external_test_connection/pct_relational.pure
@@ -996,7 +996,7 @@ function <<test.Test>> meta::relational::tests::pct::process::tests::functionRep
 function <<test.Test>> meta::relational::tests::pct::process::tests::functionReprocess::testClassAsVariableReprocess():Boolean[1]
 {
   let vals = [^SimpleClass(value='myValue'), ^SimpleClass(value='myValue2')];
-  let newState = reprocess(|$vals->filter(x|$x.value == 'test'), meta::pure::testConnection::getTestConnection(DatabaseType.H2), debug());
+  let newState = reprocess(|$vals->filter(x|$x.value == 'test'), meta::pure::testConnection::getTestConnection(DatabaseType.H2), noDebug());
   assertEquals('{|meta::relational::tests::pct::process::tests::functionReprocess::SimpleClass.all()->filter({x|($x.value == \'test\')})->from(myMapping, Runtime(MyDatabase))}', meta::pure::metamodel::serialization::grammar::printFunctionDefinition($newState.first, ^meta::pure::metamodel::serialization::grammar::GContext(space='')));
   assertEquals(1, $newState.second.mapping->size());
   assertEquals(1, $newState.second.database.schemas->at(0).tables->size());
@@ -1009,7 +1009,7 @@ function <<test.Test>> meta::relational::tests::pct::process::tests::functionRep
 
 function <<test.Test>> meta::relational::tests::pct::process::tests::functionReprocess::testPrimitiveListReprocess():Boolean[1]
 {
-  let newState = reprocess(|[1,2,3,4]->filter(x|$x > 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), debug());
+  let newState = reprocess(|[1,2,3,4]->filter(x|$x > 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), noDebug());
   assertEquals('{|[1, 2, 3, 4]->filter({x|($x > 1)})->from(Runtime(MyDatabase))}', meta::pure::metamodel::serialization::grammar::printFunctionDefinition($newState.first, ^meta::pure::metamodel::serialization::grammar::GContext(space='')));
   assertEmpty($newState.second.mapping);
   assertEmpty($newState.second.database.schemas->at(0).tables);
@@ -1018,7 +1018,7 @@ function <<test.Test>> meta::relational::tests::pct::process::tests::functionRep
 
 function <<test.Test>> meta::relational::tests::pct::process::tests::functionReprocess::testPrimitiveAnyReprocess():Boolean[1]
 {
-  let newState = reprocess(|[1,'a']->filter(x|$x == 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), debug());
+  let newState = reprocess(|[1,'a']->filter(x|$x == 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), noDebug());
   assertEquals('{|[1, \'a\']->filter({x|($x == 1)})->from(Runtime(MyDatabase))}', meta::pure::metamodel::serialization::grammar::printFunctionDefinition($newState.first, ^meta::pure::metamodel::serialization::grammar::GContext(space='')));
   assertEmpty($newState.second.mapping);
   assertEmpty($newState.second.database.schemas->at(0).tables);
@@ -1028,7 +1028,7 @@ function <<test.Test>> meta::relational::tests::pct::process::tests::functionRep
 
 function <<test.Test>> meta::relational::tests::pct::process::tests::functionReprocess::testEmptySetReprocess():Boolean[1]
 {
-  let newState = reprocess(|[]->filter(x|$x > 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), debug());
+  let newState = reprocess(|[]->filter(x|$x > 1), meta::pure::testConnection::getTestConnection(DatabaseType.H2), noDebug());
   assertEquals('{|[]->filter({x|($x > 1)})->from(Runtime(MyDatabase))}', meta::pure::metamodel::serialization::grammar::printFunctionDefinition($newState.first, ^meta::pure::metamodel::serialization::grammar::GContext(space='')));
   assertEmpty($newState.second.mapping);
   assertEmpty($newState.second.database.schemas->at(0).tables);

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/pom.xml
@@ -48,9 +48,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemProperties>
-                                <DATABRICKS_API_TOKEN>${env.DATABRICKS_API_TOKEN}&gt;</DATABRICKS_API_TOKEN>
-                            </systemProperties>
+                            <systemPropertyVariables>
+                                <AWS_ACCESS_KEY_ID>${env.AWS_ACCESS_KEY_ID}</AWS_ACCESS_KEY_ID>
+                                <AWS_SECRET_ACCESS_KEY>${env.AWS_SECRET_ACCESS_KEY}</AWS_SECRET_ACCESS_KEY>
+                                <pct.external.resources.properties>${env.PCT_EXTERNAL_RESOURCES_PROPERTIES}</pct.external.resources.properties>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -189,6 +191,19 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-vault-aws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/integration/DatabricksTestConnectionIntegration.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-databricks/legend-engine-xt-relationalStore-databricks-PCT/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/test/databricks/integration/DatabricksTestConnectionIntegration.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.plan.execution.stores.relational.test.databricks.integration;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.plan.execution.stores.relational.connection.tests.api.TestConnectionIntegration;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
@@ -22,12 +23,21 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.r
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatabricksDatasourceSpecification;
 import org.finos.legend.engine.shared.core.vault.PropertiesVaultImplementation;
 import org.finos.legend.engine.shared.core.vault.Vault;
+import org.finos.legend.engine.shared.core.vault.aws.AWSVaultImplementation;
 import org.finos.legend.engine.test.shared.framework.TestServerResource;
+import software.amazon.awssdk.regions.Region;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 public class DatabricksTestConnectionIntegration implements TestConnectionIntegration, TestServerResource
 {
+    private final RelationalDatabaseConnection conn = new RelationalDatabaseConnection();
 
     @Override
     public MutableList<String> group()
@@ -44,26 +54,74 @@ public class DatabricksTestConnectionIntegration implements TestConnectionIntegr
     @Override
     public void setup()
     {
-        Properties properties = new Properties();
-        properties.put("DATABRICKS_API_TOKEN", System.getProperty("DATABRICKS_API_TOKEN"));
-        Vault.INSTANCE.registerImplementation(new PropertiesVaultImplementation(properties));
+        DatabricksDatasourceSpecification dsSpecs = new DatabricksDatasourceSpecification();
+        ApiTokenAuthenticationStrategy authSpec = new ApiTokenAuthenticationStrategy();
+
+        String pctProperties = System.getProperty("pct.external.resources.properties", System.getenv("PCT_EXTERNAL_RESOURCES_PROPERTIES"));
+        Path localPctProperties = Paths.get(pctProperties != null ? pctProperties : "");
+
+        String awsAccessKeyId = System.getProperty("AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID"));
+        String awsSecretAccessKey = System.getProperty("AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY"));
+
+        if (!Files.isDirectory(localPctProperties) && Files.isReadable(localPctProperties))
+        {
+            try (InputStream is = Files.newInputStream(localPctProperties))
+            {
+                Properties properties = new Properties();
+                properties.load(is);
+
+                Vault.INSTANCE.registerImplementation(new PropertiesVaultImplementation(properties));
+
+                dsSpecs.hostname = properties.getProperty("databricks.spec.hostname");
+                dsSpecs.port = properties.getProperty("databricks.spec.port");
+                dsSpecs.protocol = properties.getProperty("databricks.spec.protocol");
+                dsSpecs.httpPath = properties.getProperty("databricks.spec.httpPath");
+
+                authSpec.apiToken = "databricks.auth.apiToken";
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException(e);
+            }
+        }
+        else if (!StringUtils.isEmpty(awsAccessKeyId) && !StringUtils.isEmpty(awsSecretAccessKey))
+        {
+            Vault.INSTANCE.registerImplementation(
+                    new AWSVaultImplementation(
+                            awsAccessKeyId,
+                            awsSecretAccessKey,
+                            Region.US_EAST_1,
+                            "databricks"
+                    )
+            );
+
+            dsSpecs.hostname = "dbc-f0687849-717f.cloud.databricks.com";
+            dsSpecs.port = "443";
+            dsSpecs.protocol = "https";
+            dsSpecs.httpPath = "/sql/1.0/warehouses/c56852187940e5a3";
+
+            authSpec.apiToken = "integration_test.apitoken";
+        }
+        else
+        {
+            throw new IllegalStateException("Cannot initialize Databricks integration connection");
+        }
+
+        conn.type = DatabaseType.Databricks;
+        conn.databaseType = DatabaseType.Databricks;
+        conn.element = null;
+        conn.datasourceSpecification = dsSpecs;
+        conn.authenticationStrategy = authSpec;
     }
 
     @Override
     public RelationalDatabaseConnection getConnection()
     {
-        DatabricksDatasourceSpecification dsSpecs = new DatabricksDatasourceSpecification();
-        dsSpecs.hostname = "dbc-f0687849-717f.cloud.databricks.com";
-        dsSpecs.port = "443";
-        dsSpecs.protocol = "https";
-        dsSpecs.httpPath = "/sql/1.0/warehouses/c56852187940e5a3";
-        ApiTokenAuthenticationStrategy authSpec = new ApiTokenAuthenticationStrategy();
-        authSpec.apiToken = "DATABRICKS_API_TOKEN";
-        RelationalDatabaseConnection conn = new RelationalDatabaseConnection(dsSpecs, authSpec, DatabaseType.Databricks);
-        conn.type = DatabaseType.Databricks;           // for compatibility with legacy DatabaseConnection
-        conn.element = null;
-
-        return conn;
+        if (conn.datasourceSpecification == null)
+        {
+            this.setup();
+        }
+        return this.conn;
 
     }
 

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-PCT/pom.xml
@@ -49,10 +49,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <skip>false</skip>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <AWS_ACCESS_KEY_ID>${env.AWS_ACCESS_KEY_ID}</AWS_ACCESS_KEY_ID>
                                 <AWS_SECRET_ACCESS_KEY>${env.AWS_SECRET_ACCESS_KEY}</AWS_SECRET_ACCESS_KEY>
-                            </systemProperties>
+                                <pct.external.resources.properties>${env.PCT_EXTERNAL_RESOURCES_PROPERTIES}</pct.external.resources.properties>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -198,6 +199,10 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-core-pure/src/main/resources/core_relational/relational/pureToSQLQuery/pureToSQLQuery.pure
@@ -2881,7 +2881,6 @@ function <<access.private>> meta::relational::functions::pureToSqlQuery::isolate
     | let fe = $p->at($p->size()-2);
       let ft = $fe.func->functionType();
       if($ft.parameters->head().genericType->concatenate($ft.returnType)->forAll(x|
-      $fe->println();
       $x.rawType->toOne()->_subTypeOf(TabularDataSet) || $x.rawType->toOne()->_subTypeOf(meta::pure::metamodel::relation::Relation);),
                   | isolateTdsSelect($select, $query, $extensions);,
                   | ^$query(select=$select)


### PR DESCRIPTION
* Enable configuring cloud resources using a properties file

* Remove unused dependencies

* Allow to pass pct cloud resources properties using env var

* clean up unused imports/classes

* clean up unused imports/classes

#### What type of PR is this?

<!--
Choose one of the following labels :
- Improvement
- Bug Fix
-->

#### What does this PR do / why is it needed ?

<!--
Describe change being introduced by this PR.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Other notes for reviewers:

#### Does this PR introduce a user-facing change?
<!--
-->
